### PR TITLE
remove unused lib and fix hdf5 writes

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -10,7 +10,7 @@ fn main() -> miette::Result<()> {
 
     build_dftd3and4();
 
-    let library_names = ["restmatr","openblas","xc","hdf5","rest2fch","cgto"];
+    let library_names = ["restmatr","openblas","xc","hdf5","rest2fch"];
     library_names.iter().for_each(|name| {
         println!("cargo:rustc-link-lib={}",*name);
     });
@@ -24,7 +24,6 @@ fn main() -> miette::Result<()> {
     Ok(())
 
 }
-
 
 fn build_dftd3and4() {
     let rest_dir = if let Ok(rest_dir) = env::var("REST_HOME") {

--- a/src/initial_guess/mod.rs
+++ b/src/initial_guess/mod.rs
@@ -242,7 +242,7 @@ pub fn initial_guess_from_hdf5chkfile(
     let file = hdf5::File::open(chkname).unwrap();
     let scf = file.group("scf").unwrap();
     let member = scf.member_names().unwrap();
-    let e_tot = scf.dataset("e_tot").unwrap().read_scalar::<f64>().unwrap();
+    let e_tot = scf.dataset("e_tot").unwrap().read_1d::<f64>().unwrap()[0];
     if print_level>1 {
         println!("HDF5 Group: {:?} \nMembers: {:?}", scf, member);
     }
@@ -318,9 +318,9 @@ pub fn import_mo_coeff_from_hdf5chkfile(chkname: &str) -> ([MatrixFull<f64>;2], 
     let scf = file.group("scf").unwrap();
     let member = scf.member_names().unwrap();
 
-    let num_basis = scf.dataset("num_basis").unwrap().read_scalar::<usize>().unwrap();
-    let num_state = scf.dataset("num_state").unwrap().read_scalar::<usize>().unwrap();
-    let spin_channel = scf.dataset("spin_channel").unwrap().read_scalar::<usize>().unwrap();
+    let num_basis = scf.dataset("num_basis").unwrap().read_1d::<usize>().unwrap()[0];
+    let num_state = scf.dataset("num_state").unwrap().read_1d::<usize>().unwrap()[0];
+    let spin_channel = scf.dataset("spin_channel").unwrap().read_1d::<usize>().unwrap()[0];
 
     // importing MO coefficients
     let buf01 = scf.dataset("mo_coeff").unwrap().read_raw::<f64>().unwrap();

--- a/src/post_scf_analysis/mod.rs
+++ b/src/post_scf_analysis/mod.rs
@@ -154,39 +154,39 @@ pub fn save_chkfile(scf_data: &SCF) {
     let is_exist = scf.member_names().unwrap().iter().fold(false,|is_exist,x| {is_exist || x.eq("e_tot")});
     if is_exist {
         let dataset = scf.dataset("e_tot").unwrap();
-        dataset.write(&ndarray::arr0(scf_data.scf_energy));
+        dataset.write(&[scf_data.scf_energy]);
     } else {
         let builder = scf.new_dataset_builder();
-        builder.with_data(&ndarray::arr0(scf_data.scf_energy)
+        builder.with_data(&[scf_data.scf_energy]
         ).create("e_tot").unwrap();
     }
 
     let is_exist = scf.member_names().unwrap().iter().fold(false,|is_exist,x| {is_exist || x.eq("num_basis")});
     if is_exist {
         let dataset = scf.dataset("num_basis").unwrap();
-        dataset.write(&ndarray::arr0(scf_data.mol.num_basis));
+        dataset.write(&[scf_data.mol.num_basis]).unwrap();
     } else {
         let builder = scf.new_dataset_builder();
-        builder.with_data(&ndarray::arr0(scf_data.mol.num_basis)
+        builder.with_data(&[scf_data.mol.num_basis]
         ).create("num_basis").unwrap();
     }
     let is_exist = scf.member_names().unwrap().iter().fold(false,|is_exist,x| {is_exist || x.eq("spin_channel")});
     if is_exist {
         let dataset = scf.dataset("spin_channel").unwrap();
-        dataset.write(&ndarray::arr0(scf_data.mol.spin_channel));
+        dataset.write(&[scf_data.mol.spin_channel]);
     } else {
         let builder = scf.new_dataset_builder();
-        builder.with_data(&ndarray::arr0(scf_data.mol.spin_channel)
+        builder.with_data(&[scf_data.mol.spin_channel]
         ).create("spin_channel").unwrap();
     }
 
     let is_exist = scf.member_names().unwrap().iter().fold(false,|is_exist,x| {is_exist || x.eq("num_state")});
     if is_exist {
         let dataset = scf.dataset("num_state").unwrap();
-        dataset.write(&ndarray::arr0(scf_data.mol.num_state));
+        dataset.write(&[scf_data.mol.num_state]);
     } else {
         let builder = scf.new_dataset_builder();
-        builder.with_data(&ndarray::arr0(scf_data.mol.num_state)
+        builder.with_data(&[scf_data.mol.num_state]
         ).create("num_state").unwrap();
     }
 
@@ -198,10 +198,10 @@ pub fn save_chkfile(scf_data: &SCF) {
     }
     if is_exist {
         let dataset = scf.dataset("mo_coeff").unwrap();
-        dataset.write(&ndarray::arr1(&eigenvectors));
+        dataset.write(&eigenvectors);
     } else {
         let builder = scf.new_dataset_builder();
-        builder.with_data(&ndarray::arr1(&eigenvectors)).create("mo_coeff");
+        builder.with_data(&eigenvectors).create("mo_coeff");
     }
 
     let mut eigenvalues: Vec<f64> = vec![];
@@ -210,10 +210,10 @@ pub fn save_chkfile(scf_data: &SCF) {
     }
     if is_exist {
         let dataset = scf.dataset("mo_energy").unwrap();
-        dataset.write(&ndarray::arr1(&eigenvalues));
+        dataset.write(&eigenvalues);
     } else {
         let builder = scf.new_dataset_builder();
-        builder.with_data(&ndarray::arr1(&eigenvalues)).create("mo_energy");
+        builder.with_data(&eigenvalues).create("mo_energy");
     }
 
     let is_exist = scf.member_names().unwrap().iter().fold(false,|is_exist,x| {is_exist || x.eq("mo_occupation")});
@@ -223,10 +223,10 @@ pub fn save_chkfile(scf_data: &SCF) {
     }
     if is_exist {
         let dataset = scf.dataset("mo_occupation").unwrap();
-        dataset.write(&ndarray::arr1(&occ));
+        dataset.write(&occ);
     } else {
         let builder = scf.new_dataset_builder();
-        builder.with_data(&ndarray::arr1(&occ)).create("mo_occupation");
+        builder.with_data(&occ).create("mo_occupation");
     }
 
     file.close();
@@ -254,10 +254,10 @@ pub fn save_hamiltonian(scf_data: &SCF) {
     let is_hamiltonian = scf.member_names().unwrap().iter().fold(false,|is_exist,x| {is_exist || x.eq("hamiltonian")});
     if is_hamiltonian {
         let dataset = scf.dataset("hamiltonian").unwrap();
-        dataset.write(&ndarray::arr1(&hamiltonians));
+        dataset.write(&hamiltonians);
     } else {
         let builder = scf.new_dataset_builder();
-        builder.with_data(&ndarray::arr1(&hamiltonians)).create("hamiltonian");
+        builder.with_data(&hamiltonians).create("hamiltonian");
     };
     file.close();
 }
@@ -281,10 +281,10 @@ pub fn save_overlap(scf_data: &SCF) {
     let is_exist = scf.member_names().unwrap().iter().fold(false,|is_exist,x| {is_exist || x.eq("overlap")});
     if is_exist {
         let dataset = scf.dataset("overlap").unwrap();
-        dataset.write(&ndarray::arr1(&overlap.data));
+        dataset.write(&overlap.data);
     } else {
         let builder = scf.new_dataset_builder();
-        builder.with_data(&ndarray::arr1(&overlap.data)).create("overlap");
+        builder.with_data(&overlap.data).create("overlap");
     };
     file.close();
 }
@@ -313,10 +313,10 @@ pub fn save_geometry(scf_data: &SCF) {
     let is_geom = geom.member_names().unwrap().iter().fold(false,|is_exist,x| {is_exist || x.eq("position")});
     if is_geom {
         let dataset = geom.dataset("position").unwrap();
-        dataset.write(&ndarray::arr1(&geometry));
+        dataset.write(&geometry);
     } else {
         let builder = geom.new_dataset_builder();
-        builder.with_data(&ndarray::arr1(&geometry)).create("position");
+        builder.with_data(&geometry).create("position");
     }
     file.close();
 }


### PR DESCRIPTION
## Unused Library  
The `cgto` library appears to be unused in the codebase. This PR removes it to avoid compilation errors caused by its inclusion.

## HDF5 Writes  
The `hdf5` library does not support writing `ndarray::arr0` directly. This PR updates the code to use Rust slices for compatibility with the `hdf5` API.